### PR TITLE
Lexer utf8 support

### DIFF
--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -40,7 +40,7 @@ impl Lexer {
             len += 1;
             self.read_char();
         }
-        // TODO: Investigate the below - strings in rust are UTF-8
+
         return self
             .input
             .chars()
@@ -56,7 +56,7 @@ impl Lexer {
             len += 1;
             self.read_char();
         }
-        // TODO: Investigate the below - strings in rust are UTF-8
+
         return self
             .input
             .chars()

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -35,20 +35,34 @@ impl Lexer {
 
     fn read_identifier(&mut self) -> String {
         let position = self.position;
+        let mut len = 0;
         while self.is_letter(self.ch.unwrap()) {
+            len += 1;
             self.read_char();
         }
         // TODO: Investigate the below - strings in rust are UTF-8
-        return self.input[position..self.position].to_string();
+        return self
+            .input
+            .chars()
+            .skip(position)
+            .take(len)
+            .collect::<String>();
     }
 
     fn read_number(&mut self) -> String {
         let position = self.position;
+        let mut len = 0;
         while self.is_digit(self.ch.unwrap()) {
+            len += 1;
             self.read_char();
         }
         // TODO: Investigate the below - strings in rust are UTF-8
-        return self.input[position..self.position].to_string();
+        return self
+            .input
+            .chars()
+            .skip(position)
+            .take(len)
+            .collect::<String>();
     }
 
     fn is_letter(&mut self, ch: char) -> bool {

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,11 +47,26 @@ fn assert_expected_results(input: String, expected_results: Vec<Token>) {
 // #[ignore]
 #[test]
 fn test_single_variable_binding() {
-    let input = String::from("let testing =5;");
+    let input = String::from("let _testing_a = 5;");
 
     let expected_results: Vec<Token> = vec![
         Token::new(Let, "let"),
-        Token::new(Identifier, "testing"),
+        Token::new(Identifier, "_testing_a"),
+        Token::new(Assignment, "="),
+        Token::new(Integer, "5"),
+        Token::new(Semicolon, ";"),
+    ];
+
+    assert_expected_results(input, expected_results);
+}
+
+#[test]
+fn test_multi_byte_chars() {
+    let input = String::from("let 猿猿 = 5;");
+
+    let expected_results: Vec<Token> = vec![
+        Token::new(Let, "let"),
+        Token::new(Identifier, "猿猿"),
         Token::new(Assignment, "="),
         Token::new(Integer, "5"),
         Token::new(Semicolon, ";"),


### PR DESCRIPTION
Could you take a look at this? I also added a test case, which includes Japanese characters that are multi-byte length. After reading a bunch from various places, and if my understanding is correct, this is O(n) rather than the "old" solution being O(1), so performance is not great. But it seems to be working just fine. I'd appreciate your input.